### PR TITLE
Add MCP server integration for AI assistants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,13 @@ dev = [
     "build>=1.0.0",
     "twine>=4.0.0"
 ]
+mcp = [
+    "mcp[cli]>=1.0.0",
+    "tabulate>=0.9.0"
+]
+
+[project.scripts]
+tvscreener-mcp = "tvscreener.mcp:run"
 
 [tool.setuptools.packages.find]
 include = ["tvscreener*"]

--- a/tvscreener/mcp/__init__.py
+++ b/tvscreener/mcp/__init__.py
@@ -1,0 +1,20 @@
+"""
+MCP (Model Context Protocol) server for tvscreener.
+
+This module provides an MCP server that exposes tvscreener functionality
+to AI assistants like Claude.
+
+Usage:
+    # Run directly
+    python -m tvscreener.mcp
+
+    # Or use the CLI entry point (after installing with mcp extra)
+    tvscreener-mcp
+
+    # Register with Claude Code
+    claude mcp add tvscreener -- tvscreener-mcp
+"""
+
+from .server import mcp, run
+
+__all__ = ["mcp", "run"]

--- a/tvscreener/mcp/__main__.py
+++ b/tvscreener/mcp/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for running MCP server as a module."""
+
+from .server import run
+
+if __name__ == "__main__":
+    run()

--- a/tvscreener/mcp/server.py
+++ b/tvscreener/mcp/server.py
@@ -1,0 +1,360 @@
+"""
+MCP server for tvscreener.
+
+Exposes market screener functionality via the Model Context Protocol.
+"""
+
+from __future__ import annotations
+
+import json
+from mcp.server.fastmcp import FastMCP
+
+from .tools import (
+    search_fields,
+    get_field_categories,
+    custom_screen,
+    screen_stocks,
+    screen_crypto,
+    screen_forex,
+)
+
+
+mcp = FastMCP(
+    "tvscreener",
+    instructions=(
+        "Query market screener for stocks, crypto, and forex via tvscreener library. "
+        "Use discover_fields to find available fields, then use custom_query for flexible filtering."
+    )
+)
+
+
+# =============================================================================
+# FIELD DISCOVERY TOOLS
+# =============================================================================
+
+@mcp.tool()
+def discover_fields(
+    search_term: str,
+    asset_type: str = "stock",
+    limit: int = 20
+) -> str:
+    """
+    Search for available fields/indicators by keyword.
+
+    Use this to find field names for custom_query. There are 3500+ fields available.
+
+    Args:
+        search_term: Keyword to search (e.g., "rsi", "volume", "earnings", "dividend", "macd", "moving_average")
+        asset_type: "stock", "crypto", "forex", "bond", "futures", or "coin"
+        limit: Maximum results (default 20)
+
+    Returns:
+        List of matching field names and descriptions
+
+    Examples:
+        - discover_fields("rsi") -> finds RSI indicator fields
+        - discover_fields("earnings") -> finds earnings-related fields
+        - discover_fields("dividend") -> finds dividend fields
+    """
+    fields = search_fields(search_term, asset_type, limit)
+
+    if not fields:
+        return f"No fields found matching '{search_term}'"
+
+    result = f"Found {len(fields)} fields matching '{search_term}':\n\n"
+    for f in fields:
+        tech_marker = " [Technical]" if f.get("is_technical") else ""
+        result += f"- **{f['name']}**: {f['display_name']}{tech_marker}\n"
+
+    return result
+
+
+@mcp.tool()
+def list_field_types(asset_type: str = "stock") -> str:
+    """
+    List available field categories with sample fields.
+
+    Use this to explore what types of data are available before using discover_fields.
+
+    Args:
+        asset_type: "stock", "crypto", "forex", "bond", "futures", or "coin"
+
+    Returns:
+        Categories and sample field names
+    """
+    categories = get_field_categories(asset_type)
+
+    result = f"Field categories for {asset_type}:\n\n"
+    for category, fields in categories.items():
+        result += f"**{category}**:\n"
+        for f in fields:
+            result += f"  - {f}\n"
+        result += "\n"
+
+    result += "\nUse discover_fields('keyword') to find more fields in each category."
+    return result
+
+
+# =============================================================================
+# FLEXIBLE QUERY TOOL
+# =============================================================================
+
+@mcp.tool()
+def custom_query(
+    asset_type: str = "stock",
+    fields: str | None = None,
+    filters: str | None = None,
+    sort_by: str | None = None,
+    ascending: bool = False,
+    limit: int = 25
+) -> str:
+    """
+    Flexible query with any fields and filters.
+
+    Use discover_fields first to find available field names.
+
+    Args:
+        asset_type: "stock", "crypto", "forex", "bond", "futures", or "coin"
+        fields: Comma-separated field names to return (e.g., "NAME,PRICE,RSI,MACD_LEVEL_12_26")
+                If not specified, returns default fields.
+        filters: JSON array of filter conditions. Each filter has:
+                 - field: Field name (use discover_fields to find names)
+                 - op: Operator (">=", ">", "<=", "<", "==", "!=", "match", "in_range")
+                 - value: Value to compare (use [min, max] array for in_range)
+
+                 Example: '[{"field": "PRICE", "op": ">=", "value": 100}, {"field": "RSI", "op": "in_range", "value": [30, 70]}]'
+        sort_by: Field name to sort by
+        ascending: Sort direction (default False = descending)
+        limit: Maximum results (default 25, max 100)
+
+    Returns:
+        Markdown table with query results
+
+    Examples:
+        1. Stocks with RSI between 30-70 and price > $50:
+           fields="NAME,PRICE,RSI,VOLUME"
+           filters='[{"field": "PRICE", "op": ">", "value": 50}, {"field": "RSI", "op": "in_range", "value": [30, 70]}]'
+
+        2. High dividend stocks:
+           fields="NAME,PRICE,DIVIDEND_YIELD_FY"
+           filters='[{"field": "DIVIDEND_YIELD_FY", "op": ">=", "value": 3}]'
+           sort_by="DIVIDEND_YIELD_FY"
+    """
+    # Parse fields
+    select_fields = None
+    if fields:
+        select_fields = [f.strip() for f in fields.split(",")]
+
+    # Parse filters
+    filter_list = None
+    if filters:
+        try:
+            filter_list = json.loads(filters)
+        except json.JSONDecodeError as e:
+            return f"Error parsing filters JSON: {e}"
+
+    limit = min(limit, 100)
+
+    try:
+        df = custom_screen(
+            asset_type=asset_type,
+            select_fields=select_fields,
+            filters=filter_list,
+            sort_by=sort_by,
+            ascending=ascending,
+            limit=limit
+        )
+
+        if df.empty:
+            return "No results found matching the criteria."
+
+        return df.to_markdown(index=False)
+    except Exception as e:
+        return f"Error executing query: {e}"
+
+
+# =============================================================================
+# PRESET QUERY TOOLS
+# =============================================================================
+
+@mcp.tool()
+def search_stocks(
+    min_price: float | None = None,
+    max_price: float | None = None,
+    min_market_cap_billions: float | None = None,
+    max_market_cap_billions: float | None = None,
+    sectors: str | None = None,
+    sort_by: str = "market_cap",
+    limit: int = 25
+) -> str:
+    """
+    Screen stocks with common filters (simplified interface).
+
+    For advanced filtering, use custom_query with discover_fields.
+
+    Args:
+        min_price: Minimum stock price in USD
+        max_price: Maximum stock price in USD
+        min_market_cap_billions: Minimum market cap in billions USD
+        max_market_cap_billions: Maximum market cap in billions USD
+        sectors: Comma-separated sectors (Technology, Healthcare, Financial, etc.)
+        sort_by: Sort by 'market_cap', 'price', 'volume', or 'change'
+        limit: Maximum results (default 25, max 100)
+    """
+    min_cap = min_market_cap_billions * 1e9 if min_market_cap_billions else None
+    max_cap = max_market_cap_billions * 1e9 if max_market_cap_billions else None
+    sector_list = [s.strip() for s in sectors.split(",")] if sectors else None
+    limit = min(limit, 100)
+
+    df = screen_stocks(
+        min_price=min_price,
+        max_price=max_price,
+        min_market_cap=min_cap,
+        max_market_cap=max_cap,
+        sectors=sector_list,
+        sort_by=sort_by,
+        limit=limit
+    )
+
+    if df.empty:
+        return "No stocks found matching the criteria."
+
+    return df.to_markdown(index=False)
+
+
+@mcp.tool()
+def search_crypto(
+    min_volume_millions: float | None = None,
+    min_market_cap_billions: float | None = None,
+    limit: int = 25
+) -> str:
+    """
+    Screen cryptocurrencies (simplified interface).
+
+    For advanced filtering, use custom_query with discover_fields.
+
+    Args:
+        min_volume_millions: Minimum 24h trading volume in millions USD
+        min_market_cap_billions: Minimum market cap in billions USD
+        limit: Maximum results (default 25, max 100)
+    """
+    min_vol = min_volume_millions * 1e6 if min_volume_millions else None
+    min_cap = min_market_cap_billions * 1e9 if min_market_cap_billions else None
+    limit = min(limit, 100)
+
+    df = screen_crypto(
+        min_volume_24h=min_vol,
+        min_market_cap=min_cap,
+        limit=limit
+    )
+
+    if df.empty:
+        return "No cryptocurrencies found matching the criteria."
+
+    return df.to_markdown(index=False)
+
+
+@mcp.tool()
+def search_forex(
+    min_volume_millions: float | None = None,
+    limit: int = 25
+) -> str:
+    """
+    Screen forex currency pairs.
+
+    Args:
+        min_volume_millions: Minimum trading volume in millions
+        limit: Maximum results (default 25, max 100)
+    """
+    min_vol = min_volume_millions * 1e6 if min_volume_millions else None
+    limit = min(limit, 100)
+
+    df = screen_forex(min_volume=min_vol, limit=limit)
+
+    if df.empty:
+        return "No forex pairs found matching the criteria."
+
+    return df.to_markdown(index=False)
+
+
+@mcp.tool()
+def get_top_movers(
+    asset_type: str = "stock",
+    direction: str = "gainers",
+    limit: int = 10
+) -> str:
+    """
+    Get top gaining or losing assets.
+
+    Args:
+        asset_type: "stock" or "crypto"
+        direction: "gainers" or "losers"
+        limit: Number of results (default 10, max 50)
+    """
+    limit = min(limit, 50)
+    ascending = direction.lower() == "losers"
+
+    if asset_type.lower() == "crypto":
+        df = screen_crypto(sort_by="change", ascending=ascending, limit=limit)
+    else:
+        df = screen_stocks(sort_by="change", ascending=ascending, limit=limit)
+
+    direction_label = "Losers" if ascending else "Gainers"
+
+    if df.empty:
+        return f"No {asset_type} data available."
+
+    return f"Top {direction_label}:\n\n" + df.to_markdown(index=False)
+
+
+@mcp.tool()
+def list_sectors() -> str:
+    """List available stock sectors for filtering."""
+    sectors = [
+        "Technology", "Healthcare", "Financial", "Consumer Cyclical",
+        "Communication Services", "Industrials", "Consumer Defensive",
+        "Energy", "Basic Materials", "Real Estate", "Utilities",
+        "Electronic Technology", "Technology Services", "Producer Manufacturing"
+    ]
+    return "Available sectors:\n" + "\n".join(f"  - {s}" for s in sectors)
+
+
+@mcp.tool()
+def list_filter_operators() -> str:
+    """List available filter operators for custom_query."""
+    operators = {
+        ">=": "Greater than or equal",
+        ">": "Greater than",
+        "<=": "Less than or equal",
+        "<": "Less than",
+        "==": "Equal to",
+        "!=": "Not equal to",
+        "match": "Text contains (for text fields like SECTOR)",
+        "in_range": "Value between [min, max] (e.g., RSI between 30-70)",
+        "not_in_range": "Value outside [min, max]",
+        "crosses": "Value crosses another",
+        "crosses_up": "Value crosses above another",
+        "crosses_down": "Value crosses below another",
+    }
+
+    result = "Available filter operators for custom_query:\n\n"
+    for op, desc in operators.items():
+        result += f"- **{op}**: {desc}\n"
+
+    result += "\nExample filters JSON:\n"
+    result += '```json\n[\n'
+    result += '  {"field": "PRICE", "op": ">=", "value": 100},\n'
+    result += '  {"field": "RSI", "op": "in_range", "value": [30, 70]},\n'
+    result += '  {"field": "SECTOR", "op": "match", "value": "Technology"}\n'
+    result += ']\n```'
+
+    return result
+
+
+def run():
+    """Run the MCP server."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    run()

--- a/tvscreener/mcp/tools.py
+++ b/tvscreener/mcp/tools.py
@@ -1,0 +1,333 @@
+"""
+Helper functions for MCP tools.
+
+These functions provide a clean interface between MCP tools and the tvscreener library.
+"""
+
+from __future__ import annotations
+
+import tvscreener as tvs
+from tvscreener import (
+    StockField, CryptoField, ForexField, BondField, FuturesField, CoinField,
+    FilterOperator
+)
+import pandas as pd
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+# Mapping from string operators to FilterOperator enum
+FILTER_OP_MAP = {
+    ">=": FilterOperator.ABOVE_OR_EQUAL,
+    ">": FilterOperator.ABOVE,
+    "<=": FilterOperator.BELOW_OR_EQUAL,
+    "<": FilterOperator.BELOW,
+    "==": FilterOperator.EQUAL,
+    "!=": FilterOperator.NOT_EQUAL,
+    "in_range": FilterOperator.IN_RANGE,
+    "not_in_range": FilterOperator.NOT_IN_RANGE,
+    "match": FilterOperator.MATCH,
+    "crosses": FilterOperator.CROSSES,
+    "crosses_up": FilterOperator.CROSSES_UP,
+    "crosses_down": FilterOperator.CROSSES_DOWN,
+}
+
+# Mapping from asset type to field class and screener class
+ASSET_CONFIG = {
+    "stock": {"field_class": StockField, "screener_class": tvs.StockScreener},
+    "crypto": {"field_class": CryptoField, "screener_class": tvs.CryptoScreener},
+    "forex": {"field_class": ForexField, "screener_class": tvs.ForexScreener},
+    "bond": {"field_class": BondField, "screener_class": tvs.BondScreener},
+    "futures": {"field_class": FuturesField, "screener_class": tvs.FuturesScreener},
+    "coin": {"field_class": CoinField, "screener_class": tvs.CoinScreener},
+}
+
+
+def get_field_enum(field_name: str, asset_type: str = "stock"):
+    """
+    Get the field enum from a field name string.
+
+    Args:
+        field_name: Name of the field (e.g., "PRICE", "RSI", "VOLUME")
+        asset_type: Asset type ("stock", "crypto", "forex", "bond", "futures", "coin")
+
+    Returns:
+        Field enum or None if not found
+    """
+    field_name = field_name.upper().replace(" ", "_")
+    config = ASSET_CONFIG.get(asset_type, ASSET_CONFIG["stock"])
+    field_class = config["field_class"]
+
+    # Try direct attribute access first
+    if hasattr(field_class, field_name):
+        return getattr(field_class, field_name)
+
+    # Fall back to search
+    results = field_class.search(field_name)
+    if results:
+        return results[0]
+
+    return None
+
+
+def search_fields(
+    query: str,
+    asset_type: str = "stock",
+    limit: int = 20
+) -> list[dict[str, Any]]:
+    """
+    Search for available fields by keyword.
+
+    Args:
+        query: Search keyword (e.g., "rsi", "volume", "earnings")
+        asset_type: Asset type
+        limit: Maximum results to return
+
+    Returns:
+        List of matching field info dicts with 'name', 'display_name', 'is_technical'
+    """
+    config = ASSET_CONFIG.get(asset_type, ASSET_CONFIG["stock"])
+    field_class = config["field_class"]
+
+    results = field_class.search(query)[:limit]
+
+    fields = []
+    for f in results:
+        # Field value tuple: (display_name, api_field, format, is_technical, is_recommendation)
+        value = f.value
+        fields.append({
+            "name": f.name,
+            "display_name": value[0] if len(value) > 0 else f.name,
+            "is_technical": value[3] if len(value) > 3 else False,
+        })
+
+    return fields
+
+
+def get_field_categories(asset_type: str = "stock") -> dict[str, list[str]]:
+    """
+    Get field categories with sample fields.
+
+    Args:
+        asset_type: Asset type
+
+    Returns:
+        Dict mapping category names to lists of field names
+    """
+    config = ASSET_CONFIG.get(asset_type, ASSET_CONFIG["stock"])
+    field_class = config["field_class"]
+
+    category_keywords = [
+        "price", "volume", "moving_average", "rsi", "macd",
+        "bollinger", "earnings", "dividend", "market_cap",
+        "sector", "recommend"
+    ]
+
+    categories = {}
+    for keyword in category_keywords:
+        fields = [f.name for f in field_class.search(keyword)[:5]]
+        if fields:
+            categories[keyword] = fields
+
+    return categories
+
+
+def custom_screen(
+    asset_type: str = "stock",
+    select_fields: list[str] | None = None,
+    filters: list[dict[str, Any]] | None = None,
+    sort_by: str | None = None,
+    ascending: bool = False,
+    limit: int = 25
+) -> pd.DataFrame:
+    """
+    Flexible screener with custom fields and filters.
+
+    Args:
+        asset_type: Asset type
+        select_fields: List of field names to return
+        filters: List of filter dicts: {"field": str, "op": str, "value": any}
+        sort_by: Field name to sort by
+        ascending: Sort direction
+        limit: Maximum results
+
+    Returns:
+        DataFrame with query results
+    """
+    config = ASSET_CONFIG.get(asset_type, ASSET_CONFIG["stock"])
+    screener = config["screener_class"]()
+
+    # Select fields
+    if select_fields:
+        fields_to_select = []
+        for fname in select_fields:
+            field = get_field_enum(fname, asset_type)
+            if field:
+                fields_to_select.append(field)
+        if fields_to_select:
+            screener.select(*fields_to_select)
+
+    # Apply filters
+    if filters:
+        for f in filters:
+            field_name = f.get("field")
+            op = f.get("op", ">=")
+            value = f.get("value")
+
+            field = get_field_enum(field_name, asset_type)
+            if not field:
+                continue
+
+            filter_op = FILTER_OP_MAP.get(op)
+            if not filter_op:
+                continue
+
+            screener.where(field, filter_op, value)
+
+    # Apply sorting
+    if sort_by:
+        sort_field = get_field_enum(sort_by, asset_type)
+        if sort_field:
+            screener.sort_by(sort_field, ascending=ascending)
+
+    df = screener.get()
+    return df.head(limit)
+
+
+def screen_stocks(
+    min_price: float | None = None,
+    max_price: float | None = None,
+    min_market_cap: float | None = None,
+    max_market_cap: float | None = None,
+    sectors: list[str] | None = None,
+    sort_by: str = "market_cap",
+    ascending: bool = False,
+    limit: int = 25
+) -> pd.DataFrame:
+    """
+    Screen stocks with common filters.
+
+    Args:
+        min_price: Minimum stock price
+        max_price: Maximum stock price
+        min_market_cap: Minimum market cap
+        max_market_cap: Maximum market cap
+        sectors: List of sectors to filter
+        sort_by: Sort field ('market_cap', 'price', 'volume', 'change')
+        ascending: Sort direction
+        limit: Maximum results
+
+    Returns:
+        DataFrame with matching stocks
+    """
+    ss = tvs.StockScreener()
+
+    ss.select(
+        StockField.NAME,
+        StockField.PRICE,
+        StockField.CHANGE_PERCENT,
+        StockField.VOLUME,
+        StockField.MARKET_CAPITALIZATION,
+        StockField.PRICE_TO_EARNINGS_RATIO_TTM,
+        StockField.SECTOR
+    )
+
+    if min_price is not None:
+        ss.where(StockField.PRICE, FilterOperator.ABOVE_OR_EQUAL, min_price)
+    if max_price is not None:
+        ss.where(StockField.PRICE, FilterOperator.BELOW_OR_EQUAL, max_price)
+    if min_market_cap is not None:
+        ss.where(StockField.MARKET_CAPITALIZATION, FilterOperator.ABOVE_OR_EQUAL, min_market_cap)
+    if max_market_cap is not None:
+        ss.where(StockField.MARKET_CAPITALIZATION, FilterOperator.BELOW_OR_EQUAL, max_market_cap)
+    if sectors:
+        for s in sectors:
+            ss.where(StockField.SECTOR, FilterOperator.MATCH, s)
+
+    sort_field_map = {
+        "market_cap": StockField.MARKET_CAPITALIZATION,
+        "price": StockField.PRICE,
+        "volume": StockField.VOLUME,
+        "change": StockField.CHANGE_PERCENT,
+    }
+    if sort_by in sort_field_map:
+        ss.sort_by(sort_field_map[sort_by], ascending=ascending)
+
+    return ss.get().head(limit)
+
+
+def screen_crypto(
+    min_volume_24h: float | None = None,
+    min_market_cap: float | None = None,
+    sort_by: str = "market_cap",
+    ascending: bool = False,
+    limit: int = 25
+) -> pd.DataFrame:
+    """
+    Screen cryptocurrencies with common filters.
+
+    Args:
+        min_volume_24h: Minimum 24h trading volume
+        min_market_cap: Minimum market cap
+        sort_by: Sort field ('market_cap', 'volume', 'change')
+        ascending: Sort direction
+        limit: Maximum results
+
+    Returns:
+        DataFrame with matching cryptocurrencies
+    """
+    cs = tvs.CryptoScreener()
+
+    cs.select(
+        CryptoField.NAME,
+        CryptoField.PRICE,
+        CryptoField.CHANGE_PERCENT,
+        CryptoField.VOLUME_24H_IN_USD,
+        CryptoField.MARKET_CAPITALIZATION
+    )
+
+    if min_volume_24h is not None:
+        cs.where(CryptoField.VOLUME_24H_IN_USD, FilterOperator.ABOVE_OR_EQUAL, min_volume_24h)
+    if min_market_cap is not None:
+        cs.where(CryptoField.MARKET_CAPITALIZATION, FilterOperator.ABOVE_OR_EQUAL, min_market_cap)
+
+    sort_field_map = {
+        "market_cap": CryptoField.MARKET_CAPITALIZATION,
+        "volume": CryptoField.VOLUME_24H_IN_USD,
+        "change": CryptoField.CHANGE_PERCENT,
+    }
+    if sort_by in sort_field_map:
+        cs.sort_by(sort_field_map[sort_by], ascending=ascending)
+
+    return cs.get().head(limit)
+
+
+def screen_forex(
+    min_volume: float | None = None,
+    limit: int = 25
+) -> pd.DataFrame:
+    """
+    Screen forex currency pairs.
+
+    Args:
+        min_volume: Minimum trading volume
+        limit: Maximum results
+
+    Returns:
+        DataFrame with matching forex pairs
+    """
+    fs = tvs.ForexScreener()
+
+    fs.select(
+        ForexField.NAME,
+        ForexField.PRICE,
+        ForexField.CHANGE_PERCENT,
+        ForexField.VOLUME
+    )
+
+    if min_volume is not None:
+        fs.where(ForexField.VOLUME, FilterOperator.ABOVE_OR_EQUAL, min_volume)
+
+    return fs.get().head(limit)


### PR DESCRIPTION
## Summary

- Add `tvscreener.mcp` subpackage exposing tvscreener via Model Context Protocol (MCP)
- Enable AI assistants (Claude, etc.) to query market data directly
- Add optional `[mcp]` dependency and `tvscreener-mcp` CLI entry point

## Features

**Field Discovery:**
- `discover_fields` - Search 3500+ available fields by keyword
- `list_field_types` - Explore field categories

**Flexible Queries:**
- `custom_query` - Query any fields with filters (>=, in_range, match, etc.)

**Preset Screeners:**
- `search_stocks` - Screen stocks by price, market cap, sector
- `search_crypto` - Screen crypto by volume, market cap
- `search_forex` - Screen forex pairs
- `get_top_movers` - Get top gainers/losers

## Installation

```bash
pip install tvscreener[mcp]
```

## Usage

```bash
# Run MCP server
tvscreener-mcp

# Or as module
python -m tvscreener.mcp

# Register with Claude Code
claude mcp add tvscreener -- tvscreener-mcp
```

## Test plan

- [ ] Install with `pip install -e .[mcp]`
- [ ] Run `tvscreener-mcp` and verify server starts
- [ ] Test with Claude Code or MCP inspector

🤖 Generated with [Claude Code](https://claude.com/claude-code)