### PR TITLE
fix(field): expose has_recommendation on interval/history wrappers

### DIFF
--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -17,6 +17,18 @@ class TestUtil(unittest.TestCase):
         columns = get_columns_to_request(StockField)
         self.assertIsInstance(columns, dict)
 
+    def test_get_columns_with_interval_field(self):
+        rsi_1h = StockField.RELATIVE_STRENGTH_INDEX_14.with_interval('60')
+        columns = get_columns_to_request([StockField.NAME, rsi_1h])
+        self.assertIsInstance(columns, dict)
+        self.assertIn("RSI|60", columns)
+
+    def test_get_columns_with_history_field(self):
+        rsi_hist = StockField.RELATIVE_STRENGTH_INDEX_14.with_history(3)
+        columns = get_columns_to_request([StockField.NAME, rsi_hist])
+        self.assertIsInstance(columns, dict)
+        self.assertIn("RSI[3]", columns)
+
     def test_get_recommendation(self):
         self.assertEqual("S", get_recommendation(-1))
         self.assertEqual("N", get_recommendation(0))

--- a/tvscreener/field/__init__.py
+++ b/tvscreener/field/__init__.py
@@ -303,6 +303,9 @@ class FieldWithInterval:
         self.historical = field.historical
         self.name = f"{field.name}_{interval}"  # For repr in FieldCondition
 
+    def has_recommendation(self):
+        return self.field.has_recommendation()
+
     def __repr__(self):
         return f"FieldWithInterval({self.field.name}, interval='{self._interval}')"
 
@@ -380,6 +383,9 @@ class FieldWithHistory:
         self.interval = field.interval
         self.historical = True
         self.name = f"{field.name}_history_{periods}"  # For repr in FieldCondition
+
+    def has_recommendation(self):
+        return self.field.has_recommendation()
 
     def __repr__(self):
         return f"FieldWithHistory({self.field.name}, periods={self.periods})"


### PR DESCRIPTION
Because `get_columns_to_request()` calls `field.has_recommendation()`,
`select()` broke when using indicator fields with `with_interval()`/`with_history()`.
Verified live: RSI(60m) selection now returns 150 forex pairs. Unit tests pass (115 total).